### PR TITLE
Fix `npx` cache discrepancies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
           echo "NODE_VERSION=$(node -v)" >> $GITHUB_ENV
           echo "NPM_CACHE_DIR=$(npm config get cache)" >> $GITHUB_ENV
           echo "NPM_VERSION=$(npm -v)" >> $GITHUB_ENV
-          bash ./list-npx-cache.bash
 
       - name: Cache dependencies
         if: env.CI_SKIP == 'false'
@@ -82,15 +81,15 @@ jobs:
             ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}
 
       - name: Install dependencies
-        if: env.CI_SKIP == 'false' && steps.npm-cache.outputs.cache-hit != 'true'
+        if: env.CI_SKIP == 'false'
         run: |
+          bash ./list-npx-cache.bash
           npm ci --quiet
           bash ./list-npx-cache.bash
 
       - name: Lint
         if: env.CI_SKIP == 'false'
         run: |
-          bash ./list-npx-cache.bash
           # npm run lint:build
 
       - name: Test
@@ -110,7 +109,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage/lcov.info
           flags: unit_tests
-
-      - name: Remove npx cache
-        run: |
-          # rm -rf ${{ env.NPM_CACHE_DIR }}/_npx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,8 @@ jobs:
     timeout-minutes: 120
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        # os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         target: [16.x]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ${{ env.NPM_CACHE_DIR }}
-            !${{ env.NPM_CACHE_DIR }}/_npx
+            ${{ env.NPM_CACHE_DIR }}/**
+            !${{ env.NPM_CACHE_DIR }}/_npx/**
           key: ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage/lcov.info
           flags: unit_tests
+
+      - name: Remove npx cache
+        run: |
+          rm -rf ${{ env.NPM_CACHE_DIR }}/_npx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
         if: env.CI_SKIP == 'false'
         run: |
           npm ci --quiet
+          bash ~/.list-npx-cache.bash
 
       - name: Lint
         if: env.CI_SKIP == 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
       #   if: env.CI_SKIP == 'false'
       #   run: |
       #     npm i -g npm@latest
-      #     which npm
       #     echo "NODE_VERSION=$(node -v)" >> $GITHUB_ENV
       #     echo "NPM_CACHE_DIR=$(npm config get cache)" >> $GITHUB_ENV
       #     echo "NPM_VERSION=$(npm -v)" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
           key: ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-
+        post: |
+          bash ./list-npx-cache.bash
 
       - name: Install dependencies
         if: env.CI_SKIP == 'false' && steps.npm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ${{ env.NPM_CACHE_DIR }}
+            ${{ env.NPM_CACHE_DIR }}/**
+            !${{ env.NPM_CACHE_DIR }}/_npx/**
           key: ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,22 +54,22 @@ jobs:
         with:
           node-version: ${{ matrix.target }}
 
-      - name: Install latest npm
-        if: env.CI_SKIP == 'false'
-        run: |
-          npm i -g npm@latest
-          which npm
-          echo "NODE_VERSION=$(node -v)" >> $GITHUB_ENV
-          echo "NPM_CACHE_DIR=$(npm config get cache)" >> $GITHUB_ENV
-          echo "NPM_VERSION=$(npm -v)" >> $GITHUB_ENV
+      # - name: Install latest npm
+      #   if: env.CI_SKIP == 'false'
+      #   run: |
+      #     npm i -g npm@latest
+      #     which npm
+      #     echo "NODE_VERSION=$(node -v)" >> $GITHUB_ENV
+      #     echo "NPM_CACHE_DIR=$(npm config get cache)" >> $GITHUB_ENV
+      #     echo "NPM_VERSION=$(npm -v)" >> $GITHUB_ENV
 
       - name: List versions
         if: env.CI_SKIP == 'false'
         run: |
           pwd && ls -la
-          # echo "NODE_VERSION=$(node -v)" >> $GITHUB_ENV
-          # echo "NPM_CACHE_DIR=$(npm config get cache)" >> $GITHUB_ENV
-          # echo "NPM_VERSION=$(npm -v)" >> $GITHUB_ENV
+          echo "NODE_VERSION=$(node -v)" >> $GITHUB_ENV
+          echo "NPM_CACHE_DIR=$(npm config get cache)" >> $GITHUB_ENV
+          echo "NPM_VERSION=$(npm -v)" >> $GITHUB_ENV
 
       - name: Cache dependencies
         if: env.CI_SKIP == 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,19 +54,22 @@ jobs:
         with:
           node-version: ${{ matrix.target }}
 
-      - name: Install latest npm
-        if: env.CI_SKIP == 'false'
-        run: |
-          npm i -g npm@latest
-          which npm
-          echo "NODE_VERSION=$(node -v)" >> $GITHUB_ENV
-          echo "NPM_CACHE_DIR=$(npm config get cache)" >> $GITHUB_ENV
-          echo "NPM_VERSION=$(npm -v)" >> $GITHUB_ENV
+      # - name: Install latest npm
+      #   if: env.CI_SKIP == 'false'
+      #   run: |
+      #     npm i -g npm@latest
+      #     which npm
+      #     echo "NODE_VERSION=$(node -v)" >> $GITHUB_ENV
+      #     echo "NPM_CACHE_DIR=$(npm config get cache)" >> $GITHUB_ENV
+      #     echo "NPM_VERSION=$(npm -v)" >> $GITHUB_ENV
 
       - name: List versions
         if: env.CI_SKIP == 'false'
         run: |
           pwd && ls -la
+          echo "NODE_VERSION=$(node -v)" >> $GITHUB_ENV
+          echo "NPM_CACHE_DIR=$(npm config get cache)" >> $GITHUB_ENV
+          echo "NPM_VERSION=$(npm -v)" >> $GITHUB_ENV
 
       - name: Cache dependencies
         if: env.CI_SKIP == 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ${{ env.NPM_CACHE_DIR }}/**
+            ${{ env.NPM_CACHE_DIR }}/*
             !${{ env.NPM_CACHE_DIR }}/_npx
           key: ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ${{ env.NPM_CACHE_DIR }}/**
-            !${{ env.NPM_CACHE_DIR }}/_npx/**
+            ${{ env.NPM_CACHE_DIR }}
+            !${{ env.NPM_CACHE_DIR }}/_npx
           key: ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,8 @@ jobs:
       - name: Lint
         if: env.CI_SKIP == 'false'
         run: |
-          npm run lint:build
           bash ./list-npx-cache.bash
+          npm run lint:build
 
       - name: Test
         if: env.CI_SKIP == 'false' && !contains(matrix.os, 'ubuntu')
@@ -101,7 +101,7 @@ jobs:
       - name: Test with coverage
         if: env.CI_SKIP == 'false' && contains(matrix.os, 'ubuntu')
         run: |
-          npm run test:coverage
+          # npm run test:coverage
 
       - name: Upload coverage to codecov
         if: env.CI_SKIP == 'false' && contains(matrix.os, 'ubuntu') && success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,19 +66,22 @@ jobs:
           echo "NODE_VERSION=$(node -v)" >> $GITHUB_ENV
           echo "NPM_CACHE_DIR=$(npm config get cache)" >> $GITHUB_ENV
           echo "NPM_VERSION=$(npm -v)" >> $GITHUB_ENV
+          bash ./list-npx-cache.bash
 
       - name: Cache dependencies
         if: env.CI_SKIP == 'false'
         id: npm-cache
         uses: actions/cache@v2
         with:
-          path: ${{ env.NPM_CACHE_DIR }}
+          path: |
+            ${{ env.NPM_CACHE_DIR }}
+            !${{ env.NPM_CACHE_DIR }}/_npx
           key: ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-
 
       - name: Install dependencies
-        if: env.CI_SKIP == 'false'
+        if: env.CI_SKIP == 'false' && steps.npm-cache.outputs.cache-hit != 'true'
         run: |
           npm ci --quiet
           bash ./list-npx-cache.bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         if: env.CI_SKIP == 'false'
         run: |
           npm ci --quiet
-          bash ./.list-npx-cache.bash
+          bash ./list-npx-cache.bash
 
       - name: Lint
         if: env.CI_SKIP == 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,22 +54,22 @@ jobs:
         with:
           node-version: ${{ matrix.target }}
 
-      # - name: Install latest npm
-      #   if: env.CI_SKIP == 'false'
-      #   run: |
-      #     npm i -g npm@latest
-      #     which npm
-      #     echo "NODE_VERSION=$(node -v)" >> $GITHUB_ENV
-      #     echo "NPM_CACHE_DIR=$(npm config get cache)" >> $GITHUB_ENV
-      #     echo "NPM_VERSION=$(npm -v)" >> $GITHUB_ENV
+      - name: Install latest npm
+        if: env.CI_SKIP == 'false'
+        run: |
+          npm i -g npm@latest
+          which npm
+          echo "NODE_VERSION=$(node -v)" >> $GITHUB_ENV
+          echo "NPM_CACHE_DIR=$(npm config get cache)" >> $GITHUB_ENV
+          echo "NPM_VERSION=$(npm -v)" >> $GITHUB_ENV
 
       - name: List versions
         if: env.CI_SKIP == 'false'
         run: |
           pwd && ls -la
-          echo "NODE_VERSION=$(node -v)" >> $GITHUB_ENV
-          echo "NPM_CACHE_DIR=$(npm config get cache)" >> $GITHUB_ENV
-          echo "NPM_VERSION=$(npm -v)" >> $GITHUB_ENV
+          # echo "NODE_VERSION=$(node -v)" >> $GITHUB_ENV
+          # echo "NPM_CACHE_DIR=$(npm config get cache)" >> $GITHUB_ENV
+          # echo "NPM_VERSION=$(npm -v)" >> $GITHUB_ENV
 
       - name: Cache dependencies
         if: env.CI_SKIP == 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,7 @@ jobs:
     timeout-minutes: 120
     strategy:
       matrix:
-        # os: [macos-latest, ubuntu-latest, windows-latest]
-        os: [ubuntu-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
         target: [16.x]
 
     steps:
@@ -91,7 +90,7 @@ jobs:
       - name: Lint
         if: env.CI_SKIP == 'false'
         run: |
-          # npm run lint:build
+          npm run lint:build
 
       - name: Test
         if: env.CI_SKIP == 'false' && !contains(matrix.os, 'ubuntu')
@@ -101,7 +100,7 @@ jobs:
       - name: Test with coverage
         if: env.CI_SKIP == 'false' && contains(matrix.os, 'ubuntu')
         run: |
-          # npm run test:coverage
+          npm run test:coverage
 
       - name: Upload coverage to codecov
         if: env.CI_SKIP == 'false' && contains(matrix.os, 'ubuntu') && success()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         id: npm-cache
         uses: actions/cache@v2
         with:
+          # See this glob workaround at https://github.com/actions/toolkit/issues/713.
           path: |
             ${{ env.NPM_CACHE_DIR }}/*
             !${{ env.NPM_CACHE_DIR }}/_npx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,6 @@ jobs:
       #   if: env.CI_SKIP == 'false'
       #   run: |
       #     npm i -g npm@latest
-      #     echo "NODE_VERSION=$(node -v)" >> $GITHUB_ENV
-      #     echo "NPM_CACHE_DIR=$(npm config get cache)" >> $GITHUB_ENV
-      #     echo "NPM_VERSION=$(npm -v)" >> $GITHUB_ENV
 
       - name: List versions
         if: env.CI_SKIP == 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,6 @@ jobs:
           key: ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-
-        post: |
-          bash ./list-npx-cache.bash
 
       - name: Install dependencies
         if: env.CI_SKIP == 'false' && steps.npm-cache.outputs.cache-hit != 'true'
@@ -92,6 +90,7 @@ jobs:
         if: env.CI_SKIP == 'false'
         run: |
           npm run lint:build
+          bash ./list-npx-cache.bash
 
       - name: Test
         if: env.CI_SKIP == 'false' && !contains(matrix.os, 'ubuntu')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         if: env.CI_SKIP == 'false'
         run: |
           bash ./list-npx-cache.bash
-          npm ci --quiet
+          npm ci
           bash ./list-npx-cache.bash
 
       - name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ${{ env.NPM_CACHE_DIR }}
+            ${{ env.NPM_CACHE_DIR }}/**
             !${{ env.NPM_CACHE_DIR }}/_npx
-          key: ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-${{ hashFiles('**/package-lock.json') }}-1
+          key: ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-1-
+            ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}
 
       - name: Install dependencies
         if: env.CI_SKIP == 'false' && steps.npm-cache.outputs.cache-hit != 'true'
@@ -113,4 +113,4 @@ jobs:
 
       - name: Remove npx cache
         run: |
-          rm -rf ${{ env.NPM_CACHE_DIR }}/_npx
+          # rm -rf ${{ env.NPM_CACHE_DIR }}/_npx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,9 @@ jobs:
           path: |
             ${{ env.NPM_CACHE_DIR }}
             !${{ env.NPM_CACHE_DIR }}/_npx
-          key: ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-${{ hashFiles('**/package-lock.json') }}-1
           restore-keys: |
-            ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-
+            ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-1-
 
       - name: Install dependencies
         if: env.CI_SKIP == 'false' && steps.npm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: |
-            ${{ env.NPM_CACHE_DIR }}/**
-            !${{ env.NPM_CACHE_DIR }}/_npx/**
+            ${{ env.NPM_CACHE_DIR }}
           key: ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ matrix.os }}-node-${{ env.NODE_VERSION }}-npm-${{ env.NPM_VERSION }}-
@@ -91,7 +90,7 @@ jobs:
         if: env.CI_SKIP == 'false'
         run: |
           bash ./list-npx-cache.bash
-          npm run lint:build
+          # npm run lint:build
 
       - name: Test
         if: env.CI_SKIP == 'false' && !contains(matrix.os, 'ubuntu')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         if: env.CI_SKIP == 'false'
         run: |
           npm ci --quiet
-          bash ~/.list-npx-cache.bash
+          bash ./.list-npx-cache.bash
 
       - name: Lint
         if: env.CI_SKIP == 'false'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --quiet
+          npm ci
 
       - name: Publish to npm (Prerelease)
         if: contains(github.ref, '-') == true

--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,5 @@
 # User config
+foreground-scripts=true
 preid=rc
 progress=true
 quiet=true

--- a/list-npx-cache.bash
+++ b/list-npx-cache.bash
@@ -8,7 +8,8 @@ files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules' | gre
 
 for a in $files
 do
-  echo $a
+  echo "::group::$a"
   cat $a
   echo $'\n'
+  echo "::endgroup::"
 done

--- a/list-npx-cache.bash
+++ b/list-npx-cache.bash
@@ -14,4 +14,4 @@
 #   echo "::endgroup::"
 # done
 
-ls -lhR $(npm config get cache)
+ls -lhR $(npm config get cache) || echo 'nil'

--- a/list-npx-cache.bash
+++ b/list-npx-cache.bash
@@ -4,12 +4,13 @@
 # There is an additional zx found in the npx cache when compared to the local npx cache using 8.1.4.
 
 # files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
-files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules')
+# files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules')
+files=$(find $(npm config get cache) -type f | grep -v 'node_modules')
 
 for a in $files
 do
   echo "::group::$a"
-  cat $a
+  # cat $a
   echo $'\n'
   echo "::endgroup::"
 done

--- a/list-npx-cache.bash
+++ b/list-npx-cache.bash
@@ -7,10 +7,9 @@ NPX_CACHE_DIR="$(npm config get cache)/_npx"
 
 if [[ -d $NPX_CACHE_DIR ]]; then
   FILES=$(find $NPX_CACHE_DIR -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
-  # files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules')
+  # FILES=$(find $NPX_CACHE_DIR -type f | grep -v 'node_modules')
 
   echo '[INFO] Listing all files in the npx cache...'
-  echo $'\n'
 
   for a in $FILES
   do
@@ -21,9 +20,9 @@ if [[ -d $NPX_CACHE_DIR ]]; then
   done
 else
   echo '[INFO] npx cache not found!'
-  echo $'\n'
 fi
 
 # NOTE: List all files with human readable size in the npm cache
+
 # echo "::group::$(ls -lhR $(npm config get cache) || echo 'nil')"
 # echo "::endgroup::"

--- a/list-npx-cache.bash
+++ b/list-npx-cache.bash
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-# files=$(find ~/.npm/_npx -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
-files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules')
+# NOTE: THere is a discrepancy in the npx cache in npm between 8.4.1 and 8.1.4.
+# There is an additional zx found in the npx cache when compared to the local npx cache using 8.1.4.
+
+files=$(find ~/.npm/_npx -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
+# files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules')
 
 for a in $files
 do

--- a/list-npx-cache.bash
+++ b/list-npx-cache.bash
@@ -3,16 +3,17 @@
 # NOTE: THere is a discrepancy in the npx cache in npm between 8.4.1 and 8.1.4.
 # There is an additional zx found in the npx cache when compared to the local npx cache using 8.1.4.
 
-# files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
+files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
 # files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules')
 
-# for a in $files
-# do
-#   echo "::group::$a"
-#   # cat $a
-#   echo $'\n'
-#   echo "::endgroup::"
-# done
+for a in $files
+do
+  echo "::group::$a"
+  cat $a
+  echo $'\n'
+  echo "::endgroup::"
+done
 
-echo "::group::$(ls -lhR $(npm config get cache) || echo 'nil')"
-echo "::endgroup::"
+# NOTE: List all files with human readable size in the npm cache
+# echo "::group::$(ls -lhR $(npm config get cache) || echo 'nil')"
+# echo "::endgroup::"

--- a/list-npx-cache.bash
+++ b/list-npx-cache.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # files=$(find ~/.npm/_npx -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
-files=$(find ~/.npm/_npx -type f | grep -v 'node_modules')
+files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules')
 
 for a in $files
 do

--- a/list-npx-cache.bash
+++ b/list-npx-cache.bash
@@ -14,4 +14,5 @@
 #   echo "::endgroup::"
 # done
 
-ls -lhR $(npm config get cache) || echo 'nil'
+echo "::group::$(ls -lhR $(npm config get cache) || echo 'nil')"
+echo "::endgroup::"

--- a/list-npx-cache.bash
+++ b/list-npx-cache.bash
@@ -3,16 +3,26 @@
 # NOTE: THere is a discrepancy in the npx cache in npm between 8.4.1 and 8.1.4.
 # There is an additional zx found in the npx cache when compared to the local npx cache using 8.1.4.
 
-files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
-# files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules')
+NPX_CACHE_DIR="$(npm config get cache)/_npx"
 
-for a in $files
-do
-  echo "::group::$a"
-  cat $a
+if [[ -d $NPX_CACHE_DIR ]]; then
+  FILES=$(find $NPX_CACHE_DIR -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
+  # files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules')
+
+  echo '[INFO] Listing all files in the npx cache...'
   echo $'\n'
-  echo "::endgroup::"
-done
+
+  for a in $FILES
+  do
+    echo "::group::$a"
+    cat $a
+    echo $'\n'
+    echo "::endgroup::"
+  done
+else
+  echo '[INFO] npx cache not found!'
+  echo $'\n'
+fi
 
 # NOTE: List all files with human readable size in the npm cache
 # echo "::group::$(ls -lhR $(npm config get cache) || echo 'nil')"

--- a/list-npx-cache.bash
+++ b/list-npx-cache.bash
@@ -5,13 +5,13 @@
 
 # files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
 # files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules')
-files=$(find $(npm config get cache) -type f | grep -v 'node_modules')
 
-for a in $files
-do
-  echo "::group::$a"
-  # cat $a
-  du -h $a
-  echo $'\n'
-  echo "::endgroup::"
-done
+# for a in $files
+# do
+#   echo "::group::$a"
+#   # cat $a
+#   echo $'\n'
+#   echo "::endgroup::"
+# done
+
+ls -lhR $(npm config get cache)

--- a/list-npx-cache.bash
+++ b/list-npx-cache.bash
@@ -3,8 +3,8 @@
 # NOTE: THere is a discrepancy in the npx cache in npm between 8.4.1 and 8.1.4.
 # There is an additional zx found in the npx cache when compared to the local npx cache using 8.1.4.
 
-files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
-# files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules')
+# files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
+files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules')
 
 for a in $files
 do

--- a/list-npx-cache.bash
+++ b/list-npx-cache.bash
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+files=$(find ~/.npm/_npx -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
+
+for a in $files
+do
+  echo $a
+  cat $a
+  echo $'\n'
+done

--- a/list-npx-cache.bash
+++ b/list-npx-cache.bash
@@ -3,7 +3,7 @@
 # NOTE: THere is a discrepancy in the npx cache in npm between 8.4.1 and 8.1.4.
 # There is an additional zx found in the npx cache when compared to the local npx cache using 8.1.4.
 
-files=$(find ~/.npm/_npx -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
+files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
 # files=$(find $(npm config get cache)/_npx -type f | grep -v 'node_modules')
 
 for a in $files

--- a/list-npx-cache.bash
+++ b/list-npx-cache.bash
@@ -11,6 +11,7 @@ for a in $files
 do
   echo "::group::$a"
   # cat $a
+  du -h $a
   echo $'\n'
   echo "::endgroup::"
 done

--- a/list-npx-cache.bash
+++ b/list-npx-cache.bash
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-files=$(find ~/.npm/_npx -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
+# files=$(find ~/.npm/_npx -type f | grep -v 'node_modules' | grep -v 'package-lock.json')
+files=$(find ~/.npm/_npx -type f | grep -v 'node_modules')
 
 for a in $files
 do

--- a/package-lock.json
+++ b/package-lock.json
@@ -526,9 +526,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "17.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.14.tgz",
-      "integrity": "sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng==",
+      "version": "17.0.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.15.tgz",
+      "integrity": "sha512-zWt4SDDv1S9WRBNxLFxFRHxdD9tvH8f5/kg5/IaLFdnSNXsDY4eL3Q3XXN+VxUnWIhyVFDwcsmAprvwXoM/ClA==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -3060,9 +3060,9 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
-      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "node_modules/simple-git-hooks": {
@@ -3826,9 +3826,9 @@
       }
     },
     "@types/node": {
-      "version": "17.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.14.tgz",
-      "integrity": "sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng==",
+      "version": "17.0.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.15.tgz",
+      "integrity": "sha512-zWt4SDDv1S9WRBNxLFxFRHxdD9tvH8f5/kg5/IaLFdnSNXsDY4eL3Q3XXN+VxUnWIhyVFDwcsmAprvwXoM/ClA==",
       "dev": true
     },
     "@types/node-fetch": {
@@ -5636,9 +5636,9 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
-      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "simple-git-hooks": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "lit-ntml": "^3.0.5-rc.2",
+        "lit-ntml": "^3.0.5",
         "lodash-es": "^4.17.21",
-        "normalize-diacritics": "^3.0.4-rc.2",
+        "normalize-diacritics": "^3.0.5",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -2235,9 +2235,9 @@
       }
     },
     "node_modules/lit-ntml": {
-      "version": "3.0.5-rc.2",
-      "resolved": "https://registry.npmjs.org/lit-ntml/-/lit-ntml-3.0.5-rc.2.tgz",
-      "integrity": "sha512-ZCb3zD4UXfRden2RqwhYD0xiKFjZeYZVPgbSIlFoZ3I+tFjf1SOmXCgWGOFvaRlgtcLOcR57Fp9kuBCN0rd78A==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/lit-ntml/-/lit-ntml-3.0.5.tgz",
+      "integrity": "sha512-UL6RQlcR0T4UmY69WIoshUsXe9Q5QQ8OAq7r1JBmyU70cLwhuVQXY0o8T1Qe6vhM0DjYLTmCtGMzU5p0CZKPsw==",
       "hasInstallScript": true,
       "dependencies": {
         "parse5": "^6.0.1",
@@ -2540,9 +2540,9 @@
       }
     },
     "node_modules/normalize-diacritics": {
-      "version": "3.0.4-rc.2",
-      "resolved": "https://registry.npmjs.org/normalize-diacritics/-/normalize-diacritics-3.0.4-rc.2.tgz",
-      "integrity": "sha512-ShHIYdXS+lFTH1geYCzZdReoDsm0icWwGxaQj7ShDmSsP0sPCo+bJCPysvd97JzmBU9aWAPfitb8Ar6f4y6K0A==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/normalize-diacritics/-/normalize-diacritics-3.0.5.tgz",
+      "integrity": "sha512-uz/mEo1e48yvQjJ19i7Pkx8yhrO5yf+7CdSwZs0DdozVo01SIAuqwm8PQp38C21XjAmprQYRRARiorJEixNylQ==",
       "hasInstallScript": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -5055,9 +5055,9 @@
       }
     },
     "lit-ntml": {
-      "version": "3.0.5-rc.2",
-      "resolved": "https://registry.npmjs.org/lit-ntml/-/lit-ntml-3.0.5-rc.2.tgz",
-      "integrity": "sha512-ZCb3zD4UXfRden2RqwhYD0xiKFjZeYZVPgbSIlFoZ3I+tFjf1SOmXCgWGOFvaRlgtcLOcR57Fp9kuBCN0rd78A==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/lit-ntml/-/lit-ntml-3.0.5.tgz",
+      "integrity": "sha512-UL6RQlcR0T4UmY69WIoshUsXe9Q5QQ8OAq7r1JBmyU70cLwhuVQXY0o8T1Qe6vhM0DjYLTmCtGMzU5p0CZKPsw==",
       "requires": {
         "parse5": "^6.0.1",
         "tslib": "^2.0.2"
@@ -5277,9 +5277,9 @@
       }
     },
     "normalize-diacritics": {
-      "version": "3.0.4-rc.2",
-      "resolved": "https://registry.npmjs.org/normalize-diacritics/-/normalize-diacritics-3.0.4-rc.2.tgz",
-      "integrity": "sha512-ShHIYdXS+lFTH1geYCzZdReoDsm0icWwGxaQj7ShDmSsP0sPCo+bJCPysvd97JzmBU9aWAPfitb8Ar6f4y6K0A==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/normalize-diacritics/-/normalize-diacritics-3.0.5.tgz",
+      "integrity": "sha512-uz/mEo1e48yvQjJ19i7Pkx8yhrO5yf+7CdSwZs0DdozVo01SIAuqwm8PQp38C21XjAmprQYRRARiorJEixNylQ==",
       "requires": {
         "tslib": "^2.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "lit-ntml": "^3.0.4",
+        "lit-ntml": "^3.0.5-rc.0",
         "lodash-es": "^4.17.21",
-        "normalize-diacritics": "^3.0.3",
+        "normalize-diacritics": "^3.0.4-rc.0",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -2235,9 +2235,9 @@
       }
     },
     "node_modules/lit-ntml": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lit-ntml/-/lit-ntml-3.0.4.tgz",
-      "integrity": "sha512-3S6rGgaOQmbBkKiOk+0SuSlivTDCQFvIOkssTnbRRbNa/h1IqUCDttwIAULEzSqyOdePlE6Osc9bPnSTmzXLiQ==",
+      "version": "3.0.5-rc.0",
+      "resolved": "https://registry.npmjs.org/lit-ntml/-/lit-ntml-3.0.5-rc.0.tgz",
+      "integrity": "sha512-HyoA8X+tSOWGPLsLOaGevrs+vggS5wGknm08mYrsH+UvLdpvPPGWwmc9oGYVcu/xotL4xEA9G3cpvoKBawHrYw==",
       "hasInstallScript": true,
       "dependencies": {
         "parse5": "^6.0.1",
@@ -2540,9 +2540,9 @@
       }
     },
     "node_modules/normalize-diacritics": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/normalize-diacritics/-/normalize-diacritics-3.0.3.tgz",
-      "integrity": "sha512-byATE4eQa3R/mKcnquZI/jxxZxne6VtmjhkHeZh4XdNJBUTj3YdyitVBfop8yyWEyxZGyEWtsh5npLAg/9L2bg==",
+      "version": "3.0.4-rc.0",
+      "resolved": "https://registry.npmjs.org/normalize-diacritics/-/normalize-diacritics-3.0.4-rc.0.tgz",
+      "integrity": "sha512-Zs07THVSwLnvL5dGI+GwLbzb9DI0QnmMu6TK0SnuOghTQOHGZZT6ByyglSasnvVG/cnYLWICK8/pg+/RtyS+fw==",
       "hasInstallScript": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -5055,9 +5055,9 @@
       }
     },
     "lit-ntml": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lit-ntml/-/lit-ntml-3.0.4.tgz",
-      "integrity": "sha512-3S6rGgaOQmbBkKiOk+0SuSlivTDCQFvIOkssTnbRRbNa/h1IqUCDttwIAULEzSqyOdePlE6Osc9bPnSTmzXLiQ==",
+      "version": "3.0.5-rc.0",
+      "resolved": "https://registry.npmjs.org/lit-ntml/-/lit-ntml-3.0.5-rc.0.tgz",
+      "integrity": "sha512-HyoA8X+tSOWGPLsLOaGevrs+vggS5wGknm08mYrsH+UvLdpvPPGWwmc9oGYVcu/xotL4xEA9G3cpvoKBawHrYw==",
       "requires": {
         "parse5": "^6.0.1",
         "tslib": "^2.0.2"
@@ -5277,9 +5277,9 @@
       }
     },
     "normalize-diacritics": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/normalize-diacritics/-/normalize-diacritics-3.0.3.tgz",
-      "integrity": "sha512-byATE4eQa3R/mKcnquZI/jxxZxne6VtmjhkHeZh4XdNJBUTj3YdyitVBfop8yyWEyxZGyEWtsh5npLAg/9L2bg==",
+      "version": "3.0.4-rc.0",
+      "resolved": "https://registry.npmjs.org/normalize-diacritics/-/normalize-diacritics-3.0.4-rc.0.tgz",
+      "integrity": "sha512-Zs07THVSwLnvL5dGI+GwLbzb9DI0QnmMu6TK0SnuOghTQOHGZZT6ByyglSasnvVG/cnYLWICK8/pg+/RtyS+fw==",
       "requires": {
         "tslib": "^2.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "lit-ntml": "^3.0.5-rc.0",
+        "lit-ntml": "^3.0.5-rc.2",
         "lodash-es": "^4.17.21",
-        "normalize-diacritics": "^3.0.4-rc.0",
+        "normalize-diacritics": "^3.0.4-rc.2",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
@@ -2235,9 +2235,9 @@
       }
     },
     "node_modules/lit-ntml": {
-      "version": "3.0.5-rc.0",
-      "resolved": "https://registry.npmjs.org/lit-ntml/-/lit-ntml-3.0.5-rc.0.tgz",
-      "integrity": "sha512-HyoA8X+tSOWGPLsLOaGevrs+vggS5wGknm08mYrsH+UvLdpvPPGWwmc9oGYVcu/xotL4xEA9G3cpvoKBawHrYw==",
+      "version": "3.0.5-rc.2",
+      "resolved": "https://registry.npmjs.org/lit-ntml/-/lit-ntml-3.0.5-rc.2.tgz",
+      "integrity": "sha512-ZCb3zD4UXfRden2RqwhYD0xiKFjZeYZVPgbSIlFoZ3I+tFjf1SOmXCgWGOFvaRlgtcLOcR57Fp9kuBCN0rd78A==",
       "hasInstallScript": true,
       "dependencies": {
         "parse5": "^6.0.1",
@@ -2540,9 +2540,9 @@
       }
     },
     "node_modules/normalize-diacritics": {
-      "version": "3.0.4-rc.0",
-      "resolved": "https://registry.npmjs.org/normalize-diacritics/-/normalize-diacritics-3.0.4-rc.0.tgz",
-      "integrity": "sha512-Zs07THVSwLnvL5dGI+GwLbzb9DI0QnmMu6TK0SnuOghTQOHGZZT6ByyglSasnvVG/cnYLWICK8/pg+/RtyS+fw==",
+      "version": "3.0.4-rc.2",
+      "resolved": "https://registry.npmjs.org/normalize-diacritics/-/normalize-diacritics-3.0.4-rc.2.tgz",
+      "integrity": "sha512-ShHIYdXS+lFTH1geYCzZdReoDsm0icWwGxaQj7ShDmSsP0sPCo+bJCPysvd97JzmBU9aWAPfitb8Ar6f4y6K0A==",
       "hasInstallScript": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -5055,9 +5055,9 @@
       }
     },
     "lit-ntml": {
-      "version": "3.0.5-rc.0",
-      "resolved": "https://registry.npmjs.org/lit-ntml/-/lit-ntml-3.0.5-rc.0.tgz",
-      "integrity": "sha512-HyoA8X+tSOWGPLsLOaGevrs+vggS5wGknm08mYrsH+UvLdpvPPGWwmc9oGYVcu/xotL4xEA9G3cpvoKBawHrYw==",
+      "version": "3.0.5-rc.2",
+      "resolved": "https://registry.npmjs.org/lit-ntml/-/lit-ntml-3.0.5-rc.2.tgz",
+      "integrity": "sha512-ZCb3zD4UXfRden2RqwhYD0xiKFjZeYZVPgbSIlFoZ3I+tFjf1SOmXCgWGOFvaRlgtcLOcR57Fp9kuBCN0rd78A==",
       "requires": {
         "parse5": "^6.0.1",
         "tslib": "^2.0.2"
@@ -5277,9 +5277,9 @@
       }
     },
     "normalize-diacritics": {
-      "version": "3.0.4-rc.0",
-      "resolved": "https://registry.npmjs.org/normalize-diacritics/-/normalize-diacritics-3.0.4-rc.0.tgz",
-      "integrity": "sha512-Zs07THVSwLnvL5dGI+GwLbzb9DI0QnmMu6TK0SnuOghTQOHGZZT6ByyglSasnvVG/cnYLWICK8/pg+/RtyS+fw==",
+      "version": "3.0.4-rc.2",
+      "resolved": "https://registry.npmjs.org/normalize-diacritics/-/normalize-diacritics-3.0.4-rc.2.tgz",
+      "integrity": "sha512-ShHIYdXS+lFTH1geYCzZdReoDsm0icWwGxaQj7ShDmSsP0sPCo+bJCPysvd97JzmBU9aWAPfitb8Ar6f4y6K0A==",
       "requires": {
         "tslib": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
   "scripts": {
     "build": "npm run clean && tsc",
     "clean": "rm -rf .*cache *.log .swc/ coverage/ dist/ logs/",
-    "postinstall": "npm x -y -- zx@latest ./postinstall.mjs",
+    "postinstall": "ls -la ~/.npm && npm x -y -- zx@latest ./postinstall.mjs",
     "lint": "eslint src --ext .js,.ts",
     "lint:build": "npm run lint -- --config .build.eslintrc.json",
     "lint:commit": "npm x -y -- commitlint@latest --edit",

--- a/package.json
+++ b/package.json
@@ -127,10 +127,10 @@
   "scripts": {
     "build": "npm run clean && tsc",
     "clean": "rm -rf .*cache *.log .swc/ coverage/ dist/ logs/",
-    "postinstall": "npm x -y -- zx@4.x ./postinstall.mjs",
+    "postinstall": "npm x -y -- zx@latest ./postinstall.mjs",
     "lint": "eslint src --ext .js,.ts",
     "lint:build": "npm run lint -- --config .build.eslintrc.json",
-    "lint:commit": "npm x -y -- commitlint@16.x --edit",
+    "lint:commit": "npm x -y -- commitlint@latest --edit",
     "pre-commit": "package-check && nano-staged && tsc --noEmit",
     "prepublishOnly": "package-check && npm run lint:build && npm run build",
     "test": "uvu -r @swc/register -r esm src/__tests__",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
   "scripts": {
     "build": "npm run clean && tsc",
     "clean": "rm -rf .*cache *.log .swc/ coverage/ dist/ logs/",
-    "postinstall": "npm x -y -- zx@latest ./postinstall.mjs",
+    "postinstall": "bash postinstall.bash",
     "lint": "eslint src --ext .js,.ts",
     "lint:build": "npm run lint -- --config .build.eslintrc.json",
     "lint:commit": "npm x -y -- commitlint@latest --edit",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
   "scripts": {
     "build": "npm run clean && tsc",
     "clean": "rm -rf .*cache *.log .swc/ coverage/ dist/ logs/",
-    "postinstall": "ls -la ~/.npm && npm x -y -- zx@latest ./postinstall.mjs",
+    "postinstall": "npm x -y -- zx@latest ./postinstall.mjs",
     "lint": "eslint src --ext .js,.ts",
     "lint:build": "npm run lint -- --config .build.eslintrc.json",
     "lint:commit": "npm x -y -- commitlint@latest --edit",
@@ -148,9 +148,9 @@
     ]
   },
   "dependencies": {
-    "lit-ntml": "^3.0.4",
+    "lit-ntml": "^3.0.5-rc.0",
     "lodash-es": "^4.17.21",
-    "normalize-diacritics": "^3.0.3",
+    "normalize-diacritics": "^3.0.4-rc.0",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -148,9 +148,9 @@
     ]
   },
   "dependencies": {
-    "lit-ntml": "^3.0.5-rc.0",
+    "lit-ntml": "^3.0.5-rc.2",
     "lodash-es": "^4.17.21",
-    "normalize-diacritics": "^3.0.4-rc.0",
+    "normalize-diacritics": "^3.0.4-rc.2",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -148,9 +148,9 @@
     ]
   },
   "dependencies": {
-    "lit-ntml": "^3.0.5-rc.2",
+    "lit-ntml": "^3.0.5",
     "lodash-es": "^4.17.21",
-    "normalize-diacritics": "^3.0.4-rc.2",
+    "normalize-diacritics": "^3.0.5",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "dist/**/*.*js",
     "dist/**/*.d.ts.map",
     "dist/**/*.d.ts",
-    "postinstall.mjs",
+    "postinstall.*",
     "!dist/**/*test*/**/*.*"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -127,10 +127,10 @@
   "scripts": {
     "build": "npm run clean && tsc",
     "clean": "rm -rf .*cache *.log .swc/ coverage/ dist/ logs/",
-    "postinstall": "npm x --cache=.cache -y -- zx@latest ./postinstall.mjs",
+    "postinstall": "npm x -y -- zx@4.x ./postinstall.mjs",
     "lint": "eslint src --ext .js,.ts",
     "lint:build": "npm run lint -- --config .build.eslintrc.json",
-    "lint:commit": "npm x -y -- commitlint@latest --edit",
+    "lint:commit": "npm x -y -- commitlint@16.x --edit",
     "pre-commit": "package-check && nano-staged && tsc --noEmit",
     "prepublishOnly": "package-check && npm run lint:build && npm run build",
     "test": "uvu -r @swc/register -r esm src/__tests__",

--- a/postinstall.bash
+++ b/postinstall.bash
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+npm x -y -- zx@latest ./postinstall.mjs


### PR DESCRIPTION
## Issue

When there are multiple dependencies installing the same package using `npm exec` or `npx`, it creates multiple `zx` in the `_npx` cache even though all of them using the same `zx` version. For some reasons, it creates such discrepancies between runnning `npx` at working directory vs running it in `node_modules` and some dependencies of different `zx`s are relatively different as well.

## Changes

1. Trying to fix `npx` cache discrepancies by not caching `_npx` folder
1. To always run `npm` lifecycle scripts using `bash` especially on Windows as it will run using `cmd.exe` which fails the CI because `zx` does not support `cmd.exe`

## Impacts

1. Before the fix, there are up to 3 different `zx`s being cached in the `_npx` folder in different OSes. By excluding the `_npx` in the dependencies cache, it now guarantees to always have only 1 `zx` in the `_npx` folder. This also saves up to 3MB (compressed) in terms of cache size.
1. Such fix also introduces a problem where the consistency of always running the same `zx` from the `_npx` cache magically surfaced an expected issue where `zx` not being supported in Windows when executing with `cmd.exe`. For some reason, Github action step defaults to `cmd.exe` in Windows when running `postinstall` step. So any `npm` lifecycle script has to be run with `bash` for consistency's sake on all platforms.
1. The idea of always running `zx` is actually recommended as it provides the best of both worlds where one can run JavaScript code + *nix commands using JavaScript. This is particularly useful when one requires retrieving values from the environment variable (not an easy task on Windows), e.g. `const { CI } = process.env` and reading content from a JSON file (not an easy task either using `bash`), e.g. `await fs.readFile('./package.json')`.